### PR TITLE
Pin Products.DataGridField to fix issue #3 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'Products.DataGridField',
+        'Products.DataGridField>=1.9.0',
         'collective.contentrules.mailfromfield>0.2.0',
         'collective.fontawesome',
         'plone.api>=1.1.0',


### PR DESCRIPTION
The 'required' keyword was introduced in 1.9.0 of Products.DataGridField