### PR TITLE
Switching to "border-box" model for week table

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.6.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Switching to "border-box" model for week table [pnicolli]
 
 
 3.6.1 (2016-03-15)

--- a/rg/prenotazioni/adapters/slot.py
+++ b/rg/prenotazioni/adapters/slot.py
@@ -136,7 +136,9 @@ class BaseSlot(Interval):
         '''
         styles = []
         if self._upper_value and self._lower_value:
-            height = len(self) / 60 * 1.0
+            # we add 1px for each hour to account for the border
+            # between the slots
+            height = len(self) / 60 * 1.0 + len(self) / 3600
             styles.append("height:%dpx" % height)
         styles.extend(self.extra_css_styles)
         return ';'.join(styles)

--- a/rg/prenotazioni/browser/prenotazione_macros.pt
+++ b/rg/prenotazioni/browser/prenotazione_macros.pt
@@ -94,7 +94,7 @@
 <metal:macro metal:define-macro="hours_column" i18n:domain="rg.prenotazioni">
   <div class="hours" style="top:0"
         tal:attributes="style interval/css_styles|nothing"
-        tal:define="hour_style python:'top:-%spx' % (float(interval._lower_value)/60)">
+        tal:define="hour_style python:'top:-%spx' % (float(interval._lower_value)/60 + interval._lower_value / 3600)">
     <div tal:repeat="hour python:range(24)" class="hour" tal:attributes="style hour_style">
       <div tal:content="python:str(hour).zfill(2)" />
     </div>

--- a/rg/prenotazioni/browser/resources/rg-reservation.css
+++ b/rg/prenotazioni/browser/resources/rg-reservation.css
@@ -71,8 +71,8 @@ td.selected {
 }
 
 /** Week view styles **/
-#week-table-wrapper {
-  overflow: auto;
+#week-table-wrapper * {
+  box-sizing: border-box;
 }
 table#week {
   margin: auto;
@@ -148,7 +148,7 @@ table#week td {
 }
 
 #week .gates > .hours > .hour {
-  height: 59px;
+  height: 61px;
   text-align: center;
   margin-left: 1px;
   border: 1px solid #ddd;
@@ -222,7 +222,7 @@ dl.portlet ul.navTree li a.contenttype-prenotazioniday {
 }
 
 #week .slot .links a.oclock {
-    height:4px;
+    height:6px;
     display:block;
     border-top: 1px solid #eee;
 }


### PR DESCRIPTION
When zooming the browser view in or out, table borders which are supposed to be 1px wide become thinner or wider, ruining the table cells alignment.
Additionally, the cell border is not part of the first time slot of every hour, thus making all time slots equally high.

Also removed the `overflow: auto;` CSS rule from the week table, since it wasn't needed and was occasionally creating scrollbars on Firefox.